### PR TITLE
refactor: use SciMLBase.successful_retcode for ODE solutions

### DIFF
--- a/src/solver.jl
+++ b/src/solver.jl
@@ -169,7 +169,7 @@ function solve_pde!(
         saveat = saveat,
         kwargs...
     )
-    if sol.retcode != ReturnCode.Success
+    if !SciMLBase.successful_retcode(sol)
         @warn "failed to solve PDE"
     end
     # Store the solution in the struct

--- a/test/solver_tests.jl
+++ b/test/solver_tests.jl
@@ -4,7 +4,7 @@
     for T in [Float32, Float64]
         prob = RDEProblem(RDEParam{T}(N = 512, tmax = 0.01))
         solve_pde!(prob)
-        @test prob.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
+        @test SciMLBase.successful_retcode(prob.sol)
     end
 end
 
@@ -50,7 +50,7 @@ end
     for T in [Float32, Float64]
         prob = RDEProblem(RDEParam{T}(N = 512, tmax = 5.0))
         solve_pde!(prob)
-        @test prob.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
+        @test SciMLBase.successful_retcode(prob.sol)
     end
 end
 
@@ -112,10 +112,10 @@ end
     prob = RDEProblem(params)
 
     solve_pde!(prob)
-    @test prob.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
+    @test SciMLBase.successful_retcode(prob.sol)
 
     solve_pde!(prob; alg = SSPRK33(), adaptive = false)
-    @test prob.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
+    @test SciMLBase.successful_retcode(prob.sol)
 
     # Test saveframes option
     solve_pde!(prob, saveframes = 100)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns retcode checks with [OrdinaryDiffEq v7 / SciMLBase v3](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md): use `SciMLBase.successful_retcode(sol)` instead of comparing `sol.retcode` to `ReturnCode.Success`, so benign outcomes like `StalledSuccess` or `ExactSolutionLeft` are not treated as failures.

## Changes

- `solve_pde!`: warn when `!successful_retcode(sol)` instead of `sol.retcode != ReturnCode.Success`.
- Tests: assert `successful_retcode(prob.sol)` instead of equality with `Success`.

No new direct dependency: `SciMLBase` is already loaded transitively via `OrdinaryDiffEq` (same pattern as `SciMLBase.ODESolution` in `types.jl`).

## Testing

`Pkg.test()` passed locally (Julia 1.12 test env resolved to OrdinaryDiffEq v7 / SciMLBase v3).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-debc9581-68f6-4076-8285-1d6cc6c2c136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-debc9581-68f6-4076-8285-1d6cc6c2c136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

