### PR TITLE
fix(benchmark): qualify SSPRK33 for AirspeedVelocity / BenchmarkTools

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,7 +1,6 @@
 using BenchmarkTools
 using RDE
 using RDE.OrdinaryDiffEq
-using RDE.OrdinaryDiffEqSSPRK
 
 include("bench_utils.jl")
 using .BenchUtils
@@ -15,7 +14,7 @@ solver["solve_pde"] = @benchmarkable begin
     solve_pde!(
         prob;
         saveframes = BenchUtils.DEFAULT_SAVEFRAMES,
-        alg = SSPRK33(),
+        alg = RDE.OrdinaryDiffEqSSPRK.SSPRK33(),
         adaptive = false
     )
 end setup = begin
@@ -26,7 +25,7 @@ solver["solve_pde_no_smoothing_no_shift"] = @benchmarkable begin
     solve_pde!(
         prob;
         saveframes = BenchUtils.DEFAULT_SAVEFRAMES,
-        alg = SSPRK33(),
+        alg = RDE.OrdinaryDiffEqSSPRK.SSPRK33(),
         adaptive = false
     )
 end setup = begin
@@ -40,7 +39,7 @@ solver["solve_pde_no_smoothing_shift"] = @benchmarkable begin
     solve_pde!(
         prob;
         saveframes = BenchUtils.DEFAULT_SAVEFRAMES,
-        alg = SSPRK33(),
+        alg = RDE.OrdinaryDiffEqSSPRK.SSPRK33(),
         adaptive = false
     )
 end setup = begin
@@ -54,7 +53,7 @@ solver["solve_pde_smoothing_no_shift"] = @benchmarkable begin
     solve_pde!(
         prob;
         saveframes = BenchUtils.DEFAULT_SAVEFRAMES,
-        alg = SSPRK33(),
+        alg = RDE.OrdinaryDiffEqSSPRK.SSPRK33(),
         adaptive = false
     )
 end setup = begin
@@ -68,7 +67,7 @@ solver["solve_pde_smoothing_shift"] = @benchmarkable begin
     solve_pde!(
         prob;
         saveframes = BenchUtils.DEFAULT_SAVEFRAMES,
-        alg = SSPRK33(),
+        alg = RDE.OrdinaryDiffEqSSPRK.SSPRK33(),
         adaptive = false
     )
 end setup = begin


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Benchmarks comparing **tag `v0.1.0`** (latest tag) to **current working tree** (`dirty`) were run with [AirspeedVelocity.jl](https://github.com/MilesCranmer/AirspeedVelocity.jl) using:

```bash
benchpkg RDE --path=/workspace --rev=v0.1.0,dirty \
  -s /workspace/benchmark/benchmarks.jl \
  -o benchmark_results
```

The first attempt with `--bench-on=v0.1.0` (frozen script from the tag) failed on `dirty` because `SSPRK33` was resolved in the wrong module after BenchmarkTools macro expansion (`UndefVarError` in `OrdinaryDiffEq`). This change qualifies the solver as `RDE.OrdinaryDiffEqSSPRK.SSPRK33()` so the suite runs on current OrdinaryDiffEq / OrdinaryDiffEqSSPRK layouts.

## Benchmark highlights (v0.1.0 vs dirty, same machine run)

- **Microbenchmarks** (CFL, RHS, control, utils): within noise; ratios ~0.92–1.03.
- **Solver `solve_pde*`**: ~1–3% faster on dirty for several variants; `solve_pde_no_smoothing_shift` essentially unchanged.
- **`time_to_load`**: **~1.42×** (v0.1.0 slower): ~8.9 s vs ~6.3 s — interpret with care (precompile state, depot, parallel load variance).
- **Memory (solver)**: ~211 vs ~185 allocs per run on dirty (slightly more); bytes ~0.078 MB both sides.

JSON artifacts from the run are local (`benchmark_results/`); they are gitignored.

## How to reproduce

Install the CLI (see AirspeedVelocity README), then from the repo root:

```bash
benchpkg RDE --path=. --rev=v0.1.0,dirty -s benchmark/benchmarks.jl -o benchmark_results
benchpkgtable RDE --path=. --rev=v0.1.0,dirty -i benchmark_results --mode time,memory --ratio
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28e0fe2e-b090-46ad-bbc5-a45516f7c8e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28e0fe2e-b090-46ad-bbc5-a45516f7c8e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

